### PR TITLE
Remove GNU license headers

### DIFF
--- a/mesh2hrtf/Mesh2Input/exportMesh2HRTF.py
+++ b/mesh2hrtf/Mesh2Input/exportMesh2HRTF.py
@@ -1,31 +1,3 @@
-# Authors: The Mesh2HRTF developers
-#
-#                                Mesh2HRTF
-#                Copyright (C) 2015 by Harald Ziegelwanger,
-#        Acoustics Research Institute, Austrian Academy of Sciences
-#                        mesh2hrtf.sourceforge.net
-#
-# Mesh2HRTF is licensed under the GNU Lesser General Public License as
-# published by the Free Software Foundation, either version 3 of the License,
-# or (at your option) any later version. Mesh2HRTF is distributed in the hope
-# that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
-# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details. You should have received a
-# copy of the GNU LesserGeneral Public License along with Mesh2HRTF. If not,
-# see <http://www.gnu.org/licenses/lgpl.html>.
-#
-# If you use Mesh2HRTF:
-# - Provide credits:
-#   "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"
-# - In your publication, cite both articles:
-#   [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:
-#       Open-source software package for the numerical calculation of head-
-#       related transfer functions," in Proceedings of the 22nd ICSV,
-#       Florence, IT.
-#   [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical
-#       calculation of listener-specific head-related transfer functions and
-#       sound localization: Microphone model and mesh discretization," The
-#       Journal of the Acoustical Society of America, 138, 208-222.
 
 import os
 import bpy

--- a/mesh2hrtf/NumCalc/Source/NC_3dFunctions.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_3dFunctions.cpp
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_3dFunctions.cpp                                        *
  *  Description:    public functions for 3D problems                          *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *
@@ -635,7 +596,7 @@ int NC_GenerateSubelements
 
 	int nsbe = -1, nsfl = 1, i, j, ndie, nsel, idi, nsu, j1, j2, jr = 0, nsf0,
 		ngaumax = 6, ngaumin = 2;
-	double tolf = 1.3,//toleranz fŸr verhŠltnis Abstand FlŠche(subelement)
+	double tolf = 1.3,//toleranz fï¿½r verhï¿½ltnis Abstand Flï¿½che(subelement)
     faclin = 2.0, arels, scent, tcent, ratdis, xi, et, dxi = 0.0, det,
 		disfac, err_g, err_h, err_e, gauaccu = 0.001;
 	Vector<double> crdpoip(NDIM), xisp(MVX*2), etsp(MVX*2);
@@ -652,7 +613,7 @@ int NC_GenerateSubelements
 	// loop using GOTO
 Begin_Subel:
 	ndie = 0;      // number of elments to be subdivided in this loop //subdivision level (kantesb = kante 2^-j)
-	faclin *= 0.5; // length of the subelements / length of the original el. //relative KantenlŠnge der subelements 2^-j
+	faclin *= 0.5; // length of the subelements / length of the original el. //relative Kantenlï¿½nge der subelements 2^-j
 	arels = arelj*faclin*faclin; // area of the current subelements
 	nsel = nsfl;   // number of subelements to be treated in the current loop
 
@@ -797,7 +758,7 @@ Begin_Idi:
 		}
 
 		// computing the Gaussean order
-		disfac = 0.5/ratdis;//flŠche(subelement)/entfernung/2
+		disfac = 0.5/ratdis;//flï¿½che(subelement)/entfernung/2
 		ngsbp[nsbe] = ngaumax;
 		for(i=ngaumin; i<=ngaumax; i++)
 		{
@@ -881,7 +842,7 @@ void NC_SphericalHankel
     for(i=2; i<norder; i++) dY_n[i] = dY_n[i - 1]*(double)(2*i - 1)/argu -
         dY_n[i - 2];
     
-    // compute the real part of the spherical Hankel function (see K. Giebermann, "Schnelle Sumationsverfahren zur numerischen Lösung von Integralgleichungen für Streuprobleme im R^(3)", pp 87-88)
+    // compute the real part of the spherical Hankel function (see K. Giebermann, "Schnelle Sumationsverfahren zur numerischen Lï¿½sung von Integralgleichungen fï¿½r Streuprobleme im R^(3)", pp 87-88)
     dnu = (double)(norder - 1);
     
     di=(double)(2*(dnu+1)+1)/argu;

--- a/mesh2hrtf/NumCalc/Source/NC_Addresses.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_Addresses.cpp
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_Addresses.cpp                                          *
  *  Description:    computation of addresses of unknown DOFs of each element  *
  *                  in the global equation system                             *

--- a/mesh2hrtf/NumCalc/Source/NC_Arrays.h
+++ b/mesh2hrtf/NumCalc/Source/NC_Arrays.h
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_Arrays.h                                               *
  *  Description:    Definitins of vectors and matrices                        *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_CommonFunctions.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_CommonFunctions.cpp
@@ -1,49 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- *                                                                            *
- *  Change Log:                                                               *
- *      10.04.2018: kreiza: Changed the initialization from random to 0       *
- *                          This has the effect that the relativ error is     *
- *                          calculated using the right hand side              *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_CommonFunctions.cpp                                    *
  *  Description:    common public functions                                   *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_ConstantsVariables.h
+++ b/mesh2hrtf/NumCalc/Source/NC_ConstantsVariables.h
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_ConstantsVariables.h                                   *
  *  Description:    Definitins of constants and variables                     *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_EquationSystem.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_EquationSystem.cpp
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_EquationSystem.cpp                                     *
  *  Description:    set up equation system for BEM                            *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_Input.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_Input.cpp
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_Input.cpp                                              *
  *  Description:    Input data of a job                                       *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_IntegrationConstants.h
+++ b/mesh2hrtf/NumCalc/Source/NC_IntegrationConstants.h
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_IntegrationConstants.h                                 *
  *  Description:    Abscissas and weights for Gaussean numerical integration  *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_Macros.h
+++ b/mesh2hrtf/NumCalc/Source/NC_Macros.h
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_Macros.h                                               *
  *  Description:    Definitions of macros                                     *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_Main.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_Main.cpp
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_Main.cpp                                               *
  *  Description:    main and control programs of NumCalc (Acoustic BEM for    *
  *  the calculation of head-related transfer functions)                       *

--- a/mesh2hrtf/NumCalc/Source/NC_PostProcessing.cpp
+++ b/mesh2hrtf/NumCalc/Source/NC_PostProcessing.cpp
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_PostProcessing.cpp                                     *
  *  Description:    computing and writing the results of the job              *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/NumCalc/Source/NC_TypeDefinition.h
+++ b/mesh2hrtf/NumCalc/Source/NC_TypeDefinition.h
@@ -1,44 +1,5 @@
 /*===========================================================================*\
  *                                                                            *
- *                                 Mesh2HRTF                                  *
- *                Copyright (C) 2015 by Harald Ziegelwanger,                  *
- *        Acoustics Research Institute, Austrian Academy of Sciences          *
- *                        mesh2hrtf.sourceforge.net                           *
- *                                                                            *
- *--------------------------------------------------------------------------- *
- *                                                                            *
- *  Mesh2HRTF is licensed under the GNU Lesser General Public License as      *
- *  published by the Free Software Foundation, either version 3 of            *
- *  the License, or (at your option) any later version.                       *
- *                                                                            *
- *  Mesh2HRTF is distributed in the hope that it will be useful,              *
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the              *
- *  GNU Lesser General Public License for more details.                       *
- *                                                                            *
- *  You should have received a copy of the GNU LesserGeneral Public           *
- *  License along with Mesh2HRTF. If not, see                                 *
- *  <http://www.gnu.org/licenses/lgpl.html>.                                  *
- *                                                                            *
- *  If you use Mesh2HRTF:                                                     *
- *  - Provide credits:                                                        *
- *    "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"     *
- *  - In your publication, cite both articles:                                *
- *    [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF:   *
- *        Open-source software package for the numerical calculation of       *
- *        head-related transfer functions," in Proceedings of the 22nd        *
- *        ICSV, Florence, IT.                                                 *
- *    [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical    *
- *        calculation of listener-specific head-related transfer functions    *
- *        and sound localization: Microphone model and mesh discretization,"  *
- *        The Journal of the Acoustical Society of America, 138, 208-222.     *
- *                                                                            *
- \*===========================================================================*/
-
-
-
-/*===========================================================================*\
- *                                                                            *
  *  File name:      NC_TypeDefinition.h                                       *
  *  Description:    Definition of types                                       *
  *  Author:         H. Ziegelwanger, W. Kreuzer and Z.S. Chen                 *

--- a/mesh2hrtf/Output2HRTF/Matlab/EvalToolsExport2VTK.m
+++ b/mesh2hrtf/Output2HRTF/Matlab/EvalToolsExport2VTK.m
@@ -1,19 +1,3 @@
-%                                Mesh2HRTF
-%                Copyright (C) 2015 by Harald Ziegelwanger,
-%        Acoustics Research Institute, Austrian Academy of Sciences
-%                        mesh2hrtf.sourceforge.net
-% 
-% Mesh2HRTF is licensed under the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-% Mesh2HRTF is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-% You should have received a copy of the GNU LesserGeneral Public License along with Mesh2HRTF. If not, see <http://www.gnu.org/licenses/lgpl.html>.
-% 
-% If you use Mesh2HRTF:
-% - Provide credits:
-%   "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"
-% - In your publication, cite both articles:
-%   [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF: Open-source software package for the numerical calculation of head-related transfer functions," in Proceedings of the 22nd ICSV, Florence, IT.
-%   [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical calculation of listener-specific head-related transfer functions and sound localization: Microphone model and mesh discretization," The Journal of the Acoustical Society of America, 138, 208-222.
-
 function EvalToolsExport2VTK(path,nodes,elements,data,datatype)
 %EvalTools_EXPORT2VTK
 %   []=EvalTools_export2VTK(path,nodes,elements,data,datatype) exports

--- a/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_Load.m
+++ b/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_Load.m
@@ -1,22 +1,3 @@
-%                                Mesh2HRTF
-%                Copyright (C) 2015 by Harald Ziegelwanger,
-%        Acoustics Research Institute, Austrian Academy of Sciences
-%                        mesh2hrtf.sourceforge.net
-%
-% Mesh2HRTF is licensed under the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-% Mesh2HRTF is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-% You should have received a copy of the GNU LesserGeneral Public License along with Mesh2HRTF. If not, see <http://www.gnu.org/licenses/lgpl.html>.
-%
-% If you use Mesh2HRTF:
-% - Provide credits:
-%   "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"
-% - In your publication, cite both articles:
-%   [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF: Open-source software package for the numerical calculation of head-related transfer functions," in Proceedings of the 22nd ICSV, Florence, IT.
-%   [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical calculation of listener-specific head-related transfer functions and sound localization: Microphone model and mesh discretization," The Journal of the Acoustical Society of America, 138, 208-222.
-%
-% Author: Harald Ziegelwanger (Acoustics Research Institute, Austrian Academy of Sciences)
-% Co-Author(s): Katharina Pollack (Acoustics Research Institute, Austrian Academy of Sciences)
-
 function [data,frequency]=Output2HRTF_Load(foldername,filename, numFrequencies)
 %   [data,frequency] = OUTPUT2HRTF_LOAD(foldername,filename)
 %   

--- a/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_Main.m
+++ b/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_Main.m
@@ -1,22 +1,3 @@
-%                                Mesh2HRTF
-%                Copyright (C) 2015 by Harald Ziegelwanger,
-%        Acoustics Research Institute, Austrian Academy of Sciences
-%                        mesh2hrtf.sourceforge.net
-%
-% Mesh2HRTF is licensed under the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-% Mesh2HRTF is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-% You should have received a copy of the GNU LesserGeneral Public License along with Mesh2HRTF. If not, see <http://www.gnu.org/licenses/lgpl.html>.
-%
-% If you use Mesh2HRTF:
-% - Provide credits:
-%   "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"
-% - In your publication, cite both articles:
-%   [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF: Open-source software package for the numerical calculation of head-related transfer functions," in Proceedings of the 22nd ICSV, Florence, IT.
-%   [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical calculation of listener-specific head-related transfer functions and sound localization: Microphone model and mesh discretization," The Journal of the Acoustical Society of America, 138, 208-222.
-%
-% Author: Harald Ziegelwanger (Acoustics Research Institute, Austrian Academy of Sciences)
-% Co-Author(s): Fabian Brinkmann, Robert Pelzer (Audio Communication Group, Technical University Berlin), Katharina Pollack (Acoustics Research Institute, Austrian Academy of Sciences)
-
 function Output2HRTF_Main(Mesh2HRTF_version, ...
     sourceType, numSources, sourceCenter, sourceArea, ...
     reference, computeHRIRs, ...

--- a/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_ReadComputationTime.m
+++ b/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_ReadComputationTime.m
@@ -1,22 +1,3 @@
-%                                Mesh2HRTF
-%                Copyright (C) 2015 by Harald Ziegelwanger,
-%        Acoustics Research Institute, Austrian Academy of Sciences
-%                        mesh2hrtf.sourceforge.net
-% 
-% Mesh2HRTF is licensed under the GNU Lesser General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-% Mesh2HRTF is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
-% You should have received a copy of the GNU LesserGeneral Public License along with Mesh2HRTF. If not, see <http://www.gnu.org/licenses/lgpl.html>.
-% 
-% If you use Mesh2HRTF:
-% - Provide credits:
-%   "Mesh2HRTF, H. Ziegelwanger, ARI, OEAW (mesh2hrtf.sourceforge.net)"
-% - In your publication, cite both articles:
-%   [1] Ziegelwanger, H., Kreuzer, W., and Majdak, P. (2015). "Mesh2HRTF: Open-source software package for the numerical calculation of head-related transfer functions," in Proceedings of the 22nd ICSV, Florence, IT.
-%   [2] Ziegelwanger, H., Majdak, P., and Kreuzer, W. (2015). "Numerical calculation of listener-specific head-related transfer functions and sound localization: Microphone model and mesh discretization," The Journal of the Acoustical Society of America, 138, 208-222.
-%
-% Author: Harald Ziegelwanger (Acoustics Research Institute, Austrian Academy of Sciences)
-% Co-Author(s): Katharina Pollack (Acoustics Research Institute, Austrian Academy of Sciences)
-
 function data=Output2HRTF_ReadComputationTime(filename)
 %   [] = Output2HRTF_ReadBEMPerformance(filename)
 %

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU LLesser General Public License 3'
+        'License :: OSI Approved :: EUPL 1.2'
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Mesh2HRTF is now using EUPL v1.2. Old license headers are thus removed in favor of a single license in the top level repository folder.