### PR TITLE
issue #4 bugfix: computationTime

### DIFF
--- a/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_ReadComputationTime.m
+++ b/mesh2hrtf/Output2HRTF/Matlab/Output2HRTF_ReadComputationTime.m
@@ -47,12 +47,12 @@ while ~feof(fid)
         data(count,8) = sscanf(line(startIdx+23:endIdx-1), '%d');
         data(count,9) = sscanf('0', '%d');
     end
-    if ~isempty(regexp(line, '^\d+\s\d+'))
-        [idx1, idx2] = regexp(line, '\s');
-        data(count,7) = sscanf(line(idx2+1:end-1), '%f');
-        data(count,8) = sscanf(line(1:idx1-1), '%d');
-        data(count,9) = sscanf('0', '%d');
-    end
+%     if ~isempty(regexp(line, '^\d+\s\d+'))
+%         [idx1, idx2] = regexp(line, '\s');
+%         data(count,7) = sscanf(line(idx2+1:end-1), '%f');
+%         data(count,8) = sscanf(line(1:idx1-1), '%d');
+%         data(count,9) = sscanf('0', '%d');
+%     end
     if strfind(line, 'Warning: Maximum number of iterations')
         data(count,9) = sscanf('1', '%d');
     end


### PR DESCRIPTION
computationTime should now read relative error and iterations from NC(*).out correctly