### PR TITLE
Enhance manage numcalc

### DIFF
--- a/mesh2hrtf/NumCalc/manage_numcalc.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc.py
@@ -158,7 +158,8 @@ def manage_numcalc(project_path=None, numcalc_path=None,
     message += (
         f"project_path: {project_path}\n"
         f"numcalc_path: {numcalc_path}\n"
-        f"max_ram_load: {max_ram_load:.2f} GB ({total_ram:.2f} GB detected)\n"
+        f"max_ram_load: {max_ram_load:.2f} GB ({total_ram:.2f} GB detected, "
+        f"{ram_info.available / 1073741824:.2f} GB available)\n"
         f"ram_safety_factor: {ram_safety_factor}\n"
         f"max_cpu_load: {max_cpu_load} %\n"
         f"max_instances: {max_instances} "

--- a/mesh2hrtf/NumCalc/manage_numcalc.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc.py
@@ -7,9 +7,9 @@ import numpy as np
 import mesh2hrtf as m2h
 
 
-def manage_numcalc(project_path=os.getcwd(), numcalc_path=None,
+def manage_numcalc(project_path=None, numcalc_path=None,
                    max_ram_load=None, ram_safety_factor=1.05, max_cpu_load=90,
-                   max_instances=psutil.cpu_count(), wait_time=15,
+                   max_instances=None, wait_time=15,
                    starting_order='alternate', confirm_errors=False):
     """
     Run NumCalc on one or multiple Mesh2HRTF project folders.
@@ -32,7 +32,7 @@ def manage_numcalc(project_path=os.getcwd(), numcalc_path=None,
         The directory to simulate: It can be path to either
         1- directory that contains multiple Mesh2HRTF project folders or
         2- one Mesh2HRTF project folder (folder containing "parameters.json").
-        The default is os.getcwd()
+        The default ``None`` uses ``os.getcwd()``
     numcalc_path : str, optional
         On Unix, this is the path to the NumCalc binary (by default 'NumCalc'
         is used). On Windows, this is the path to the folder
@@ -42,7 +42,7 @@ def manage_numcalc(project_path=os.getcwd(), numcalc_path=None,
     max_ram_load : number, optional
         The RAM that can maximally be used in GB. New NumCalc instances are
         only started if enough RAM is available. The default ``None`` uses all
-        available RAM will be used.
+        available RAM.
     ram_safety_factor : number, optional
         A safety factor that is applied to the estimated RAM consumption. The
         estimate is obtained using NumCalc -estimate_ram. The default of
@@ -52,9 +52,9 @@ def manage_numcalc(project_path=os.getcwd(), numcalc_path=None,
         Maximum allowed CPU load in percent. New instances are only launched if
         the current CPU load is below this value. The default is 90 percent.
     max_instances : int, optional
-        The maximum numbers of parallel NumCalc instances. By default a new
-        instance is launched until the number of available CPU cores given by
-        ``psutil.cpu_count()`` is reached.
+        The maximum numbers of parallel NumCalc instances. If max_instances is
+        ``None``, by default a new instance is launched until the number of
+        available CPU cores given by ``psutil.cpu_count()`` is reached.
     wait_time : int, optional
         Delay in seconds for waiting until the RAM and CPU usage is checked
         after launching a NumCalc instance. This has to be sufficiently large
@@ -81,6 +81,9 @@ def manage_numcalc(project_path=os.getcwd(), numcalc_path=None,
     """
 
     # log_file initialization -------------------------------------------------
+    if project_path is None:
+        project_path = os.getcwd()
+
     current_time = time.strftime("%Y_%m_%d_%H-%M-%S", time.localtime())
     log_file = os.path.join(
         project_path, f"manage_numcalc_{current_time}.txt")
@@ -120,7 +123,9 @@ def manage_numcalc(project_path=os.getcwd(), numcalc_path=None,
     wait_time_busy = 1
 
     # check input -------------------------------------------------------------
-    if max_instances > psutil.cpu_count():
+    if max_instances is None:
+        max_instances = psutil.cpu_count()
+    elif max_instances > psutil.cpu_count():
         _raise_error(
             (f"max_instances is {max_instances} but can not be larger than "
              f"{psutil.cpu_count()} (The number of logical CPUs)"),

--- a/mesh2hrtf/NumCalc/manage_numcalc.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc.py
@@ -229,7 +229,13 @@ def manage_numcalc(project_path=None, numcalc_path=None,
                "-------------------------------------------------\n")
 
     message += f"Detected {len(all_projects)} Mesh2HRTF projects in\n"
-    message += f"{os.path.dirname(log_file)}\n\n"
+    message += f"{os.path.dirname(log_file)}\n"
+
+    # print already here because _check_project might produce output that
+    # should come after this
+    _print_message(message, text_color_reset, log_file)
+
+    message = "\n"
 
     for project in all_projects:
         all_instances, instances_to_run, *_ = _check_project(

--- a/mesh2hrtf/NumCalc/manage_numcalc.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc.py
@@ -316,7 +316,7 @@ def manage_numcalc(project_path=None, numcalc_path=None,
                 # print message (only done once between launching instances)
                 if started_instance:
                     _print_message(
-                        (f"\n... waiting for resources and checking every "
+                        (f"... waiting for resources and checking every "
                          f"second ({current_time})\n"
                          f"{running_instances} NumCalc instances running at "
                          f"{cpu_load:.2f}% CPU load\n"

--- a/mesh2hrtf/NumCalc/manage_numcalc.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc.py
@@ -318,11 +318,11 @@ def manage_numcalc(project_path=None, numcalc_path=None,
                     _print_message(
                         (f"\n... waiting for resources and checking every "
                          f"second ({current_time})\n"
-                         f"{running_instances} NumCalc instances running, "
+                         f"{running_instances} NumCalc instances running at "
+                         f"{cpu_load:.2f}% CPU load\n"
                          f"{round(ram_available, 2)} GB RAM available "
                          f"({ram_used:.2f} GB used), "
-                         f"{round(ram_required, 2)} GB required, "
-                         f"{cpu_load:.2f}% CPU load)\n"),
+                         f"{round(ram_required, 2)} GB required\n"),
                         text_color_reset, log_file)
                     started_instance = False
 
@@ -344,7 +344,7 @@ def manage_numcalc(project_path=None, numcalc_path=None,
             message = (
                 f"{progress}/{total_nr_to_run} starting instance from "
                 f"'{os.path.basename(project)}' ({current_time})\n"
-                f"source {source}, step {step} ({frequency} Hz)\n"
+                f"source {source}, step {step}, {frequency} Hz\n"
                 f"estimated {ram:.2f} GB RAM of available {ram_available:.2f} "
                 "GB required\n")
             _print_message(message, text_color_reset, log_file)

--- a/mesh2hrtf/NumCalc/manage_numcalc.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc.py
@@ -59,7 +59,10 @@ def manage_numcalc(project_path=None, numcalc_path=None,
         Delay in seconds for waiting until the RAM and CPU usage is checked
         after launching a NumCalc instance. This has to be sufficiently large
         for the RAM and CPU to be fully used by the started NumCalc instance.
-        The default is 15. After this initial wait time, the resources are
+        The default is 15 s but values of 60 s or even more might be required
+        depending on the machine. The RAM values that ``manage_numcalc``
+        outputs are usually a good indicator to check if `wait_time` is
+        sufficiently high. After this initial wait time, the resources are
         checked every second. And the next instance is started, once enough
         resources are available.
     starting_order : str, optional

--- a/mesh2hrtf/NumCalc/manage_numcalc_script.py
+++ b/mesh2hrtf/NumCalc/manage_numcalc_script.py
@@ -62,12 +62,16 @@ parser.add_argument(
           " by ``psutil.cpu_count()`` is reached."))
 parser.add_argument(
     "--wait_time", default=15, type=int,
-    help=("Delay in seconds for waiting until the RAM and CPU usage is checked"
-          " after launching a NumCalc instance. This has to be sufficiently "
-          "arge for the RAM and CPU to be fully used by the started NumCalc "
-          "instance. The default is 15. After this initial wait time, the "
-          "resources are checked every second. And the next instance is "
-          "started, once enough resources are available."))
+    help=(
+        "Delay in seconds for waiting until the RAM and CPU usage is checked "
+        "after launching a NumCalc instance. This has to be sufficiently "
+        "large for the RAM and CPU to be fully used by the started NumCalc "
+        "instance. The default is 15 s but values of 60 s or even more might "
+        "be required depending on the machine. The RAM values that "
+        "`manage_numcalc` outputs are usually a good indicator to check if "
+        "`wait_time` is sufficiently high. After this initial wait time, the "
+        "resources are checked every second. And the next instance is started,"
+        " once enough resources are available."))
 parser.add_argument(
     "--starting_order", default='alternate',
     choices=('alternate', 'high', 'low'), type=str,


### PR DESCRIPTION
- More simple and robust RAM management
- Improved verbosity in command line output

Here are the changes in the RAM management https://github.com/Any2HRTF/Mesh2HRTF/pull/101/commits/79d07c09236bce8aad6c768331dc7df481822c66

And this is an example of the new output

```

Starting manage_numcalc with the following arguments [May 17 2023, 21:04:01]
----------------------------------------------------------------------------
project_path: /home/bruel/Downloads/projects_empty
numcalc_path: NumCalc
max_ram_load: 30.00 GB (31.05 GB detected)
ram_safety_factor: 1.05
max_cpu_load: 90 %
max_instances: 8 (8 cores detected)
wait_time: 15 seconds
starting_order: alternate
confirm_errors: False

NumCalc executable: NumCalc

Obtaining RAM estimates for /home/bruel/Downloads/projects_empty/right_ear/NumCalc/source_1
Obtaining RAM estimates for /home/bruel/Downloads/projects_empty/left_ear/NumCalc/source_1

Per project summary of instances that will be run
-------------------------------------------------
Detected 2 Mesh2HRTF projects in
/home/bruel/Downloads/projects_empty

128/128 frequency steps to run in 'right_ear'
128/128 frequency steps to run in 'left_ear'


Started 'right_ear' project (1/2, May 17 2023, 21:04:10)
--------------------------------------------------------
Running 128/128 unfinished frequency steps in the project

1/128 starting instance from 'right_ear' (May 17 2023, 21:04:10)
source 1, step 128, 22050.0 Hz
estimated 7.99 GB RAM of available 26.36 GB required

2/128 starting instance from 'right_ear' (May 17 2023, 21:04:25)
source 1, step 30, 5167.97 Hz
estimated 4.53 GB RAM of available 18.87 GB required

3/128 starting instance from 'right_ear' (May 17 2023, 21:04:40)
source 1, step 127, 21877.7 Hz
estimated 7.99 GB RAM of available 14.61 GB required

4/128 starting instance from 'right_ear' (May 17 2023, 21:04:55)
source 1, step 33, 5684.77 Hz
estimated 4.53 GB RAM of available 7.08 GB required

... waiting for resources and checking every second (May 17 2023, 21:05:10)
4 NumCalc instances running at 51.20% CPU load
2.88 GB RAM available (27.12 GB used), 4.76 GB required
```

@chris-hld, this should be pretty much identical to #100 but does not use `psutil.psutil.virtual_memory().used` because the documentation mentions that this is for informal purposes only. It seems to work well on my machine. Can you check it on the cluster the next days?