### PR TITLE
Improve saving blender file upon project folder export

### DIFF
--- a/mesh2hrtf/Mesh2Input/mesh2input.py
+++ b/mesh2hrtf/Mesh2Input/mesh2input.py
@@ -371,7 +371,7 @@ class ExportMesh2HRTF(bpy.types.Operator, ExportHelper):
             filter_movie=False, filter_python=False, filter_font=False,
             filter_sound=False, filter_text=False, filter_btx=False,
             filter_collada=False, filter_folder=True, filemode=8,
-            compress=False, relative_remap=True, copy=False)
+            compress=True, relative_remap=True, copy=True)
 
 
 # Write evaluation grid data --------------------------------------------------


### PR DESCRIPTION
1. The `mesh2input.py` Blender addon now saves a copy of the currently opened Blender project in the Mesh2HRTF project folder. Before the project was moved to the project folder. This might not be the best option because it comes with the danger that people make changes to the Blender project after export and then save it. In this case the project might not correctly document the Mesh2HRTF project that it generated.

2. The Blender file is now saved as a compressed file to reduce the file size.

closes #99 