### PR TITLE
Fix in report issues using the Python API

### DIFF
--- a/mesh2hrtf/Output2HRTF/write_output_report.py
+++ b/mesh2hrtf/Output2HRTF/write_output_report.py
@@ -196,7 +196,7 @@ def _parse_nc_out_files(sources, num_sources, num_frequencies):
                 if "Too many integral points in the theta" not in line:
                     out[step-1, 3, ss] = 1
                 else:
-                    out[step-1, 4, ss] = 0
+                    out[step-1, 3, ss] = 0
 
                 # check and write convergence
                 if 'Maximum number of iterations is reached!' not in line:

--- a/mesh2hrtf/Output2HRTF/write_output_report.py
+++ b/mesh2hrtf/Output2HRTF/write_output_report.py
@@ -139,9 +139,6 @@ def _parse_nc_out_files(sources, num_sources, num_frequencies):
     out = -np.ones((num_frequencies, 11, num_sources))
     # values for steps
     out[:, 0] = np.arange(1, num_frequencies + 1)[..., np.newaxis]
-    # values indicating failed input check and non-convergence
-    out[:, 3] = 0
-    out[:, 4] = 0
 
     # regular expression for finding a number that can be int or float
     re_number = r"(\d+(?:\.\d+)?)"
@@ -198,10 +195,14 @@ def _parse_nc_out_files(sources, num_sources, num_frequencies):
                 # check if the input data was ok
                 if "Too many integral points in the theta" not in line:
                     out[step-1, 3, ss] = 1
+                else:
+                    out[step-1, 4, ss] = 0
 
                 # check and write convergence
                 if 'Maximum number of iterations is reached!' not in line:
                     out[step-1, 4, ss] = 1
+                else:
+                    out[step-1, 4, ss] = 0
 
                 # check iterations
                 idx = re.search(r'number of iterations = \d+,', line)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -290,7 +290,7 @@ def test_merge_sofa_files(pattern):
     [["case_3"], True,
      ["Frequency steps that were not calculated:\n59, 60",
       "Frequency steps with bad input:\n58"], []],
-    # no isses in source 1 but issues in source 2
+    # no issues in source 1 but issues in source 2
     [["case_0", "case_1"], True,
      ["Detected issues for source 2",
       "Frequency steps that were not calculated:\n59, 60"],


### PR DESCRIPTION
We assume that output files that originate from specific calls of NumCalc,,  e.g., `NC1-1.out` overwrite information from the general `NC.out` but parts of the information was not overwritten during parsing. This is now fixed and errors are reported correctly.