### PR TITLE
Add issue template to streamline support

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,17 +3,17 @@
 * Mesh2HRTF version:
 * Operating System:
 
-**Note for users of [Mesh2HRTF_tools](https://sourceforge.net/projects/mesh2hrtf-tools):** Mesh2HRTF_tools **not** part of Mesh2HRTF. Please check if your issue is caused by Mesh2HRTF_tools, in which case, post your issue [here](https://sourceforge.net/p/mesh2hrtf-tools/tickets/). The issue tracker here is only for issues related directly to Mesh2HRTF.
+**Note for users of [Mesh2HRTF_tools](https://sourceforge.net/projects/mesh2hrtf-tools):** Mesh2HRTF_tools are **not** part of Mesh2HRTF. Please check if your issue is caused by Mesh2HRTF_tools, in which case, post your issue [here](https://sourceforge.net/p/mesh2hrtf-tools/tickets/). The issue tracker here is only for issues related directly to Mesh2HRTF.
 
 ## Description
 
-Describe your problem in three steps: 
+Describe your problem in three steps:
 
 * What you were trying to do (your interaction with Mesh2HRTF).
 * What you expected to happen (expected behavior of Mesh2HRTF).
 * What actually happened (actual behavior of Mesh2HRTF).
 
-Provide all information required to reproduce these three steps. 
+Provide all information required to reproduce these three steps.
 
 ```
 Paste the command(s) you ran and the output.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,12 +3,17 @@
 * Mesh2HRTF version:
 * Operating System:
 
-**Note for [Mesh2HRTF_tools](https://sourceforge.net/projects/mesh2hrtf-tools):** This is not part of Mesh2HRTF and your issue might not be caused by Mesh2HRTF. In this case, either post your issue [here](https://sourceforge.net/p/mesh2hrtf-tools/tickets/), or report which part of Mesh2HRTF causes the issue, if you think this is the case. Unfortunately Mesh2HRTF_tools might not be maintained anymore and we cannot offer support here.
+**Note for users of [Mesh2HRTF_tools](https://sourceforge.net/projects/mesh2hrtf-tools):** Mesh2HRTF_tools **not** part of Mesh2HRTF. Please check if your issue is caused by Mesh2HRTF_tools, in which case, post your issue [here](https://sourceforge.net/p/mesh2hrtf-tools/tickets/). The issue tracker here is only for issues related directly to Mesh2HRTF.
 
 ## Description
 
-Describe what you were trying to get done.
-Tell us what happened, what went wrong, and what you expected to happen.
+Describe your problem in three steps: 
+
+* What you were trying to do (your interaction with Mesh2HRTF).
+* What you expected to happen (expected behavior of Mesh2HRTF).
+* What actually happened (actual behavior of Mesh2HRTF).
+
+Provide all information required to reproduce these three steps. 
 
 ```
 Paste the command(s) you ran and the output.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+## General
+
+* Mesh2HRTF version:
+* Operating System:
+
+**Note for [Mesh2HRTF_tools](https://sourceforge.net/projects/mesh2hrtf-tools):** This is not part of Mesh2HRTF and your issue might not be caused by Mesh2HRTF. In this case, either post your issue [here](https://sourceforge.net/p/mesh2hrtf-tools/tickets/), or report which part of Mesh2HRTF causes the issue, if you think this is the case. Unfortunately Mesh2HRTF_tools might not be maintained anymore and we cannot offer support here.
+
+## Description
+
+Describe what you were trying to get done.
+Tell us what happened, what went wrong, and what you expected to happen.
+
+```
+Paste the command(s) you ran and the output.
+```


### PR DESCRIPTION
People will see the text in ISSUE_TEMPLATE when opening an issue.