### PR TITLE
Restrict pyfar version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "scipy>=1.5.0",
     "psutil",
     "sofar>=1.0.0",
-    "pyfar>=0.6.0",
+    "pyfar>=0.6.0,<0.8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`compute_dtf` from the Mesh2HRTF Python API uses functionality that will be deprecated in pyfar 0.8. This is to make sure everything keeps working until the dependency is updated.