### PR TITLE
Fix Blender 5.1 export

### DIFF
--- a/mesh2hrtf/Mesh2Input/mesh2input.py
+++ b/mesh2hrtf/Mesh2Input/mesh2input.py
@@ -373,10 +373,7 @@ class ExportMesh2HRTF(bpy.types.Operator, ExportHelper):
 # save Blender project for documentation --------------------------------------
         bpy.ops.wm.save_as_mainfile(
             filepath=os.path.join(filepath1, "3d Model.blend"),
-            check_existing=False, filter_blender=True, filter_image=False,
-            filter_movie=False, filter_python=False, filter_font=False,
-            filter_sound=False, filter_text=False, filter_btx=False,
-            filter_collada=False, filter_folder=True, filemode=8,
+            check_existing=False, filter_blender=True, filemode=8,
             compress=True, relative_remap=True, copy=True)
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -259,7 +259,7 @@ def test_blender_export(
 
     # --- Exercise ---
     # run mesh2input from Blender command line interface w/ Python script
-    subprocess.run(
+    result = subprocess.run(  # noqa (result can be used for debugging)
         [os.path.join(blender_path, 'blender'), '--background',
          blender_file_name, '--python',
          os.path.join(tmp.name, 'blender_script.py')],


### PR DESCRIPTION
The Mesh2HRTF Blender export using Mesh2Input.py failed in Blender 5.0 and higher.

The reason was using the `filter_collada` flag when saving the blender project using `bpy.ops.wm.save_as_mainfile`. The flag was removed in Blender 5.0. Its only purpose was to not show collada files in the export user interface. Since it is not required when scripting an export this flag and all other `filter_*` flags that were used are now removed. This should be saver for future Blender releases in case other flags get removed.