### PR TITLE
Feature/mac os adaptation

### DIFF
--- a/mesh2hrtf/NumCalc/src/Makefile
+++ b/mesh2hrtf/NumCalc/src/Makefile
@@ -9,8 +9,10 @@ GSLFLAG=-DUSE_GSL
 LAPACKFLAG=-DUSE_LAPACK
 OPTIM=-O2
 GSL_PREFIX ?= /usr/local
-LDFLAGS=-llapacke -lgsl -lblas -L$(GSL_PREFIX)/lib
+LAPACK_PREFIX ?= /usr/local
+LDFLAGS=-L$(LAPACK_PREFIX)/lib -L$(GSL_PREFIX)/lib -llapacke -lgsl -lblas
 CFLAGS+=-I$(GSL_PREFIX)/include
+CFLAGS+=-I$(LAPACK_PREFIX)/include
 #DEBUG=-g
 
 all: $(SOURCES) $(EXECUTABLE)

--- a/mesh2hrtf/NumCalc/src/Makefile
+++ b/mesh2hrtf/NumCalc/src/Makefile
@@ -8,15 +8,17 @@ EXECUTABLE=../bin/NumCalc
 GSLFLAG=-DUSE_GSL
 LAPACKFLAG=-DUSE_LAPACK
 OPTIM=-O2
-LDFLAGS=-llapacke -lgsl -lblas
+GSL_PREFIX ?= /usr/local
+LDFLAGS=-llapacke -lgsl -lblas -L$(GSL_PREFIX)/lib
+CFLAGS+=-I$(GSL_PREFIX)/include
 #DEBUG=-g
 
 all: $(SOURCES) $(EXECUTABLE)
 
-$(EXECUTABLE): $(OBJECTS) 
+$(EXECUTABLE): $(OBJECTS)
 	$(CC) $(OBJECTS) $(LDFLAGS) $(OPTIM) $(GSLFLAG) $(LAPACKFLAG) -o $@
 
 .cpp.o:
-	$(CC) $(CFLAGS) $(DEBUG) $(OPTIM) $< 
+	$(CC) $(CFLAGS) $(DEBUG) $(OPTIM) $(GSLFLAG) $(LAPACKFLAG) $<
 clean:
 	rm *.o

--- a/mesh2hrtf/NumCalc/src/NC_MLFMM.cpp
+++ b/mesh2hrtf/NumCalc/src/NC_MLFMM.cpp
@@ -584,9 +584,14 @@ void Get_Interpolation_Matrices(double** Ylev, int nlevels) {
 	  if( l == 0 )
 	    //	    Ylev[lev-1][i * Ncurrent + j] = 0.25/PI;
 	    Ylev[lev-1][i * Ncurrent + j] = 1.0;
-	  else
+	  else {
 	    //	    Ylev[lev-1][i * Ncurrent + j] += (2.0 * double(l) + 1.0) / (4.0 * PI) * legendre(l,Angle);
+#ifdef USE_GSL
+	    Ylev[lev-1][i * Ncurrent + j] += (2.0 * double(l) + 1.0) * gsl_sf_legendre_Pl(l,Angle);
+#else
 	    Ylev[lev-1][i * Ncurrent + j] += (2.0 * double(l) + 1.0) * legendre(l,Angle);
+#endif
+	  }
 	}
       }
     }

--- a/mesh2hrtf/NumCalc/src/NC_MLFMM.h
+++ b/mesh2hrtf/NumCalc/src/NC_MLFMM.h
@@ -7,15 +7,14 @@
 #include<gsl/gsl_sf_bessel.h>
 #include<gsl/gsl_sf_legendre.h>
 #include<vector>
-#include <bits/stdc++.h>
-//#include<x86_64-linux-gnu/cblas64_mangling.h>
+#include<cmath>
+#include<gsl/gsl_cblas.h>
 
-#include<x86_64-linux-gnu/cblas64.h>
 extern Vector<double> Sourpoi3;
 extern Vector<double> Norvci3;
 extern void BAsinguII(ofstream&, Vector<Complex>&, const int&,
 	       const int&, Vector<Complex>&, Matrix<double>&,
-	       const int&, const int&); 
+	       const int&, const int&);
 extern void BAreguII(ofstream&, Vector<Complex>&, const int&,
 	    const int&, const int&, const int&,
 	    Vector<Complex>&, Matrix<double>&,


### PR DESCRIPTION
See [files changed](https://github.com/Any2HRTF/Mesh2HRTF/pull/179/changes) for explanations of the changes.

When running `make` I stil get one error:
```shell
NC_MLFMM.cpp:1492:19: error: variable-sized object may not be initialized
 1492 |   int nentryinrow[numRowsOfCoefficientMatrix_] = {0};
```